### PR TITLE
Add advertising address support

### DIFF
--- a/main.c
+++ b/main.c
@@ -82,7 +82,8 @@ usage(void)
     fprintf(stderr, "usage: rtpproxy [-2fvFiPa] [-l addr1[/addr2]] "
       "[-6 addr1[/addr2]] [-s path]\n\t[-t tos] [-r rdir [-S sdir]] [-T ttl] "
       "[-L nfiles] [-m port_min]\n\t[-M port_max] [-u uname[:gname]] "
-      "[-n timeout_socket] [-d log_level[:log_facility]]\n");
+      "[-n timeout_socket] [-d log_level[:log_facility]] "
+      "[-A addr1[/addr2]]\n");
     exit(1);
 }
 
@@ -118,6 +119,9 @@ init_config(struct cfg *cf, int argc, char **argv)
     cf->stable.port_min = PORT_MIN;
     cf->stable.port_max = PORT_MAX;
 
+    cf->stable.advaddr[0] = NULL;
+    cf->stable.advaddr[1] = NULL;
+
     cf->stable.max_ttl = SESSION_TIMEOUT;
     cf->stable.tos = TOS;
     cf->stable.rrtcp = 1;
@@ -132,7 +136,7 @@ init_config(struct cfg *cf, int argc, char **argv)
     if (getrlimit(RLIMIT_NOFILE, &(cf->stable.nofile_limit)) != 0)
 	err(1, "getrlimit");
 
-    while ((ch = getopt(argc, argv, "vf2Rl:6:s:S:t:r:p:T:L:m:M:u:Fin:Pad:")) != -1)
+    while ((ch = getopt(argc, argv, "vf2Rl:6:s:S:t:r:p:T:L:m:M:u:Fin:Pad:A:")) != -1)
 	switch (ch) {
 	case 'f':
 	    cf->stable.nodaemon = 1;
@@ -157,6 +161,23 @@ init_config(struct cfg *cf, int argc, char **argv)
 		cf->stable.bmode = 1;
 	    }
 	    break;
+
+    case 'A':
+        cf->stable.advaddr[0] = optarg;
+        cf->stable.advaddr[1] = strchr(cf->stable.advaddr[0], '/');
+        if (cf->stable.advaddr[1] != NULL) {
+            *cf->stable.advaddr[1] = '\0';
+            cf->stable.advaddr[1]++;
+            if (*cf->stable.advaddr[0] == 0) {
+                errx(1, "first advertised address is invalid");
+                exit(0);
+            }
+            if (*cf->stable.advaddr[1] == 0) {
+                errx(1, "second advertised address is invalid");
+                exit(0);
+            }
+        }
+        break;
 
 	case 's':
 	    if (strncmp("udp:", optarg, 4) == 0) {
@@ -366,6 +387,9 @@ init_config(struct cfg *cf, int argc, char **argv)
 	if (bh[1] != NULL && bh6[1] != NULL)
 	    errx(1, "either IPv4 or IPv6 should be configured for internal "
 	      "interface in bridging mode, not both");
+    if (cf->stable.advaddr[0] != NULL && cf->stable.advaddr[1] == NULL)
+        errx(1, "two advertised addresses are required for internal "
+          "and external interfaces in bridging mode");
 	if (i != 2)
 	    errx(1, "incomplete configuration of the bridging mode - exactly "
 	      "2 listen addresses required, %d provided", i);

--- a/rtpp_command.c
+++ b/rtpp_command.c
@@ -203,9 +203,21 @@ reply_port(struct cfg_stable *cf, int fd, struct rtpp_command *cmd,
     }
     if (lia[0] == NULL || ishostnull(lia[0]))
 	len += sprintf(cp, "%d\n", lport);
-    else
-	len += sprintf(cp, "%d %s%s\n", lport, addr2char(lia[0]),
-	  (lia[0]->sa_family == AF_INET) ? "" : " 6");
+    else {
+        if (cf->advaddr[0] != NULL) {
+            if (cf->bmode != 0 && cf->advaddr[1] != NULL
+              && lia[0] == cf->bindaddr[1]) {
+                len += sprintf(cp, "%d %s%s\n", lport, cf->advaddr[1],
+                  (lia[0]->sa_family == AF_INET) ? "" : " 6");
+            } else {
+                len += sprintf(cp, "%d %s%s\n", lport, cf->advaddr[0],
+                  (lia[0]->sa_family == AF_INET) ? "" : " 6");
+            }
+        } else {
+            len += sprintf(cp, "%d %s%s\n", lport, addr2char(lia[0]),
+              (lia[0]->sa_family == AF_INET) ? "" : " 6");
+        }
+    }
     doreply(cf, fd, buf, len, &cmd->raddr, cmd->rlen);
 }
 

--- a/rtpp_defines.h
+++ b/rtpp_defines.h
@@ -95,6 +95,7 @@ struct cfg {
          * mode enabled.
          */
         struct sockaddr *bindaddr[2];	/* RTP socket(s) addresses */
+        char *advaddr[2]; /* advertised addresses */
         int tos;
 
         const char *rdir;


### PR DESCRIPTION
This will allow using rtpproxy on servers behind NAT, such as Google Cloud Compute Engine and Amazon EC2 instances.

Adapted from https://github.com/miconda/rtpproxy/commit/41f6d9d9084a6fad52a6483a0593d4b25e0de8ca
