### PR TITLE
RFC: initial support of G.729 codec in makeann using open bcg729 library

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -72,9 +72,18 @@ if test "$found_libg729" = yes
 then
   AC_CHECK_LIB(g729, g729_encoder_new,
    LIBS_G729="-lg729"
-   G729_SUPPORT=ext
-   AC_DEFINE([ENABLE_G729], 1, [Define if you have libg729 library installed])
+   AC_DEFINE([ENABLE_G729], 1, [Define if you have G.729 support])
   )
+else
+  AC_CHECK_HEADERS(bcg729/encoder.h, found_libbcg729=yes)
+  if test "$found_libbcg729" = yes
+  then
+    AC_CHECK_LIB(bcg729, initBcg729EncoderChannel,
+     LIBS_G729=`pkg-config --libs libbcg729`
+     AC_DEFINE([ENABLE_G729], 1, [Define if you have G.729 support])
+     AC_DEFINE([ENABLE_BCG729], 1, [Define if you have bcg729 library])
+    )
+  fi
 fi
 ##if test -z "$G729_SUPPORT"
 ##then

--- a/configure.ac
+++ b/configure.ac
@@ -62,7 +62,6 @@ if test "$found_libgsm" = yes
 then
   AC_CHECK_LIB(gsm, gsm_create,
    LIBS_GSM="-lgsm"
-   GSM_SUPPORT=ext
    AC_DEFINE([ENABLE_GSM], 1, [Define if you have libgsm library installed]))
 fi
 


### PR DESCRIPTION
Hello All!
This is a working support for G.729 in makeann utility using opensouce bcg729 library:

* http://www.linphone.org/technical-corner/bcg729/overview

It works pretty well (I'm using it with makeann as well as with SEMS). However I've heard that some people expressed concerns regarding bcg729's performance compared to the proprietary counterparts. Actually makeann isn't a very performance-critical application so I'm not sure if it's necessary to maintain an "old" G.729 API.

Any comments are highly welcome!