### PR TITLE
Don't try to override UID variable

### DIFF
--- a/tests/functions
+++ b/tests/functions
@@ -1,5 +1,5 @@
 OS=`uname`
-UID=`id -u`
+MYUID=`id -u`
 
 TZ=CET
 export TZ
@@ -15,7 +15,7 @@ MAKEANN=${TOP_BUILDDIR}/makeann/makeann
 EXTRACTAUDIO=${TOP_BUILDDIR}/extractaudio/extractaudio
 DIFF="diff -u"
 TCPDUMP="tcpdump"
-if [ ${UID} -eq 0 ]
+if [ ${MYUID} -eq 0 ]
 then
   SUDO=""
 else


### PR DESCRIPTION
It seems that Bash sets it up and disallows further changing. This
generates messages like that:

FAIL: startstop
===============

./functions: line 2: UID: доступная только на чтение переменная
FAIL: startstop
===============

./functions: line 2: UID: доступная только на чтение переменная

FAIL: basic_versions
====================

./functions: line 2: UID: доступная только на чтение переменная

FAIL: command_parser
====================

./functions: line 2: UID: доступная только на чтение переменная

FAIL: makeann
=============

./functions: line 2: UID: доступная только на чтение переменная

FAIL: extractaudio
==================

./functions: line 2: UID: доступная только на чтение переменная

FAIL: session_timeouts
======================

./functions: line 2: UID: доступная только на чтение переменная

FAIL: playback1
===============

./functions: line 2: UID: доступная только на чтение переменная

FAIL: forwarding1
=================

./functions: line 2: UID: доступная только на чтение переменная

Signed-off-by: Peter Lemenkov <lemenkov@gmail.com>