### PR TITLE
Follow API changes for libsrtp2 library.

### DIFF
--- a/configure
+++ b/configure
@@ -12202,13 +12202,13 @@ fi
 
 if test "$found_libsrtp2" = yes
 then
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for srtp_init in -lsrtp" >&5
-$as_echo_n "checking for srtp_init in -lsrtp... " >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for srtp_init in -lsrtp2" >&5
+$as_echo_n "checking for srtp_init in -lsrtp2... " >&6; }
 if ${ac_cv_lib_srtp2_srtp_init+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   ac_check_lib_save_LIBS=$LIBS
-LIBS="-lsrtp  $LIBS"
+LIBS="-lsrtp2  $LIBS"
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -12239,7 +12239,7 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_srtp2_srtp_init" >&5
 $as_echo "$ac_cv_lib_srtp2_srtp_init" >&6; }
 if test "x$ac_cv_lib_srtp2_srtp_init" = xyes; then :
-  LIBS_SRTP="-lsrtp"
+  LIBS_SRTP="-lsrtp2"
 
 $as_echo "#define ENABLE_SRTP2 1" >>confdefs.h
 

--- a/configure
+++ b/configure
@@ -12193,6 +12193,60 @@ fi
 
 fi
 
+# libsrtp2
+ac_fn_c_check_header_mongrel "$LINENO" "srtp2/srtp.h" "ac_cv_header_srtp2_srtp_h" "$ac_includes_default"
+if test "x$ac_cv_header_srtp2_srtp_h" = xyes; then :
+  found_libsrtp2=yes
+fi
+
+
+if test "$found_libsrtp2" = yes
+then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for srtp_init in -lsrtp" >&5
+$as_echo_n "checking for srtp_init in -lsrtp... " >&6; }
+if ${ac_cv_lib_srtp2_srtp_init+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lsrtp  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char srtp_init ();
+int
+main ()
+{
+return srtp_init ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_lib_srtp2_srtp_init=yes
+else
+  ac_cv_lib_srtp2_srtp_init=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_srtp2_srtp_init" >&5
+$as_echo "$ac_cv_lib_srtp2_srtp_init" >&6; }
+if test "x$ac_cv_lib_srtp2_srtp_init" = xyes; then :
+  LIBS_SRTP="-lsrtp"
+
+$as_echo "#define ENABLE_SRTP2 1" >>confdefs.h
+
+fi
+
+fi
+
 # libelperiodic
 ac_fn_c_check_header_mongrel "$LINENO" "elperiodic.h" "ac_cv_header_elperiodic_h" "$ac_includes_default"
 if test "x$ac_cv_header_elperiodic_h" = xyes; then :

--- a/configure.ac
+++ b/configure.ac
@@ -130,8 +130,8 @@ fi
 AC_CHECK_HEADER(srtp2/srtp.h, found_libsrtp2=yes)
 if test "$found_libsrtp2" = yes
 then
-  AC_CHECK_LIB(srtp, srtp_init,
-   LIBS_SRTP="-lsrtp"
+  AC_CHECK_LIB(srtp2, srtp_init,
+   LIBS_SRTP="-lsrtp2"
    AC_DEFINE([ENABLE_SRTP2], 1, [Define if you have libsrtp2 library installed]))
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -126,6 +126,15 @@ then
    AC_DEFINE([ENABLE_SRTP], 1, [Define if you have libsrtp library installed]))
 fi
 
+# libsrtp2
+AC_CHECK_HEADER(srtp2/srtp.h, found_libsrtp2=yes)
+if test "$found_libsrtp2" = yes
+then
+  AC_CHECK_LIB(srtp, srtp_init,
+   LIBS_SRTP="-lsrtp"
+   AC_DEFINE([ENABLE_SRTP2], 1, [Define if you have libsrtp2 library installed]))
+fi
+
 # libelperiodic
 AC_CHECK_HEADER(elperiodic.h, found_libelperiodic=yes)
 if test "$found_libelperiodic" = yes

--- a/extractaudio/extractaudio.c
+++ b/extractaudio/extractaudio.c
@@ -66,19 +66,19 @@
 #include "rtp_analyze.h"
 #include "rtpa_stats.h"
 #include "eaud_oformats.h"
-#if ENABLE_SRTP
+#if ENABLE_SRTP || ENABLE_SRTP2
 # include "eaud_crypto.h"
 #endif
 
 /*#define EAUD_DUMPRAW "/tmp/eaud.raw"*/
 
-#if ENABLE_SRTP
+#if ENABLE_SRTP || ENABLE_SRTP2
 #define LOPT_ALICE_CRYPTO 256
 #define LOPT_BOB_CRYPTO   257
 #endif
 
 const static struct option longopts[] = {
-#if ENABLE_SRTP
+#if ENABLE_SRTP || ENABLE_SRTP2
     { "alice-crypto", required_argument, NULL, LOPT_ALICE_CRYPTO },
     { "bob-crypto",   required_argument, NULL, LOPT_BOB_CRYPTO },
 #endif
@@ -244,7 +244,7 @@ main(int argc, char **argv)
             oname = optarg;
             break;
 
-#if ENABLE_SRTP
+#if ENABLE_SRTP || ENABLE_SRTP2
         case LOPT_ALICE_CRYPTO:
             alice_crypto = eaud_crypto_getopt_parse(optarg);
             if (alice_crypto == NULL) {

--- a/extractaudio/rtpp_loader.c
+++ b/extractaudio/rtpp_loader.c
@@ -50,7 +50,7 @@
 #include "rtpp_loader.h"
 #include "rtpp_time.h"
 #include "rtpp_util.h"
-#if ENABLE_SRTP
+#if ENABLE_SRTP || ENABLE_SRTP2
 #include "eaud_crypto.h"
 #endif
 
@@ -91,7 +91,7 @@ rtpp_load(const char *path)
         return NULL;
     }
 
-#if !ENABLE_SRTP
+#if !ENABLE_SRTP && !ENABLE_SRTP2
     rval->ibuf = mmap(NULL, rval->sb.st_size, PROT_READ, MAP_SHARED,
       rval->ifd, 0);
 #else
@@ -267,7 +267,7 @@ load_pcap(struct rtpp_loader *loader, struct channels *channels,
         if (rtp_len < sizeof(rtp_hdr_t))
             continue;
 
-#if ENABLE_SRTP
+#if ENABLE_SRTP || ENABLE_SRTP2
         if (crypto != NULL) {
             rtp_pkt_len = eaud_crypto_decrypt(crypto, cp, rtp_len);
             if (rtp_pkt_len <= 0) {

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -29,6 +29,9 @@
 /* Define if you have libsrtp library installed */
 #undef ENABLE_SRTP
 
+/* Define if you have libsrtp2 library installed */
+#undef ENABLE_SRTP2
+
 /* Define to 1 if you have `alloca', as a function or macro. */
 #undef HAVE_ALLOCA
 


### PR DESCRIPTION
In [857009c1a5672fefad2974a546a5f9581fd31200](https://github.com/cisco/libsrtp/commit/857009c1a5672fefad2974a546a5f9581fd31200) John Foley changed various parts of the API to be prefixed with `srtp_`, and in [d196e02295c25dcf9d4f2ebcc34060c2c6027750](https://github.com/cisco/libsrtp/commit/d196e02295c25dcf9d4f2ebcc34060c2c6027750) xe changed the name of the library to `libsrtp2`.  This adapts to those changes, without (intentionally) changing existing behaviour.