### PR TITLE
Openwrt patches

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -278,6 +278,21 @@ AC_LINK_IFELSE(
    [AC_MSG_RESULT([no])]
 )
 
+AC_MSG_CHECKING([whether -latomic is needed for __atomic builtins])
+AC_LINK_IFELSE(
+  [AC_LANG_PROGRAM([[#include <stdint.h>]],
+    [[uint64_t val = 0; __atomic_add_fetch(&val, 1, __ATOMIC_RELAXED);]]
+  )],
+  [AC_MSG_RESULT([no])],
+  [LIBS="$LIBS -latomic"
+    AC_LINK_IFELSE(
+      [AC_LANG_PROGRAM([[#include <stdint.h>]],
+                       [[uint64_t val = 0; __atomic_add_fetch(&val, 1, __ATOMIC_RELAXED);]]
+      )],
+      [AC_MSG_RESULT([yes])],
+      [AC_MSG_FAILURE([libatomic needed, but linking with -latomic failed, cannot continue])]
+  )]
+)
 
 # <DocBook & friends>
 AX_CHECK_DOCBOOK_DTD(4.5)

--- a/libucl/Makefile.am
+++ b/libucl/Makefile.am
@@ -13,7 +13,7 @@ libucl_a_SOURCES = $(UCL_SDIR)/ucl_emitter_streamline.c \
   $(UCL_SDIR)/ucl_schema.c \
   $(UCL_SDIR)/ucl_sexp.c \
   $(UCL_SDIR)/ucl_util.c
-libucl_a_CFLAGS = -Wno-pointer-sign -std=c99 -DHAVE_CONFIG_H \
+libucl_a_CFLAGS = -Wno-pointer-sign -std=c99 -DHAVE_CONFIG_H -D_BSD_SOURCE \
   -I$(UCL_DIR)/include \
   -I$(UCL_DIR)/uthash \
   -I$(UCL_DIR)/klib \

--- a/makeann/makeann.c
+++ b/makeann/makeann.c
@@ -66,6 +66,7 @@
 #define G722_ENABLED 0
 #endif
 
+#include "rtpp_endian.h"
 #include "rtp.h"
 
 #if BYTE_ORDER == BIG_ENDIAN

--- a/modules/acct_csv/rtpp_acct_csv.c
+++ b/modules/acct_csv/rtpp_acct_csv.c
@@ -53,6 +53,7 @@
 #include "rtpp_module.h"
 #include "rtpp_netaddr.h"
 #include "rtpp_network.h"
+#include "rtpp_util.h"
 #include "rtpp_cfg_stable.h"
 #include "rtpp_log.h"
 #include "rtpp_log_obj.h"

--- a/src/rtpp_log_stand.c
+++ b/src/rtpp_log_stand.c
@@ -248,7 +248,7 @@ _rtpp_log_write_va(struct rtpp_log_inst *rli, int level, const char *function,
     fprintf(stderr, rli->format_se[0], rtpp_time_buff, strlvl(level),
       call_id, function);
     vfprintf(stderr, format, ap);
-    fprintf(stderr, rli->format_se[1]);
+    fprintf(stderr, "%s", rli->format_se[1]);
 }
 
 void

--- a/src/rtpp_memdeb.h
+++ b/src/rtpp_memdeb.h
@@ -39,6 +39,8 @@
 #include <string.h>
 #include <stdlib.h>
 
+#include <pthread.h>
+
 #if !defined(MEMDEB_APP)
 #error MEMDEB_APP has to be defined
 #endif

--- a/src/rtpp_record.c
+++ b/src/rtpp_record.c
@@ -70,6 +70,7 @@
 #include "rtpp_session.h"
 #include "rtpp_stream.h"
 #include "rtpp_time.h"
+#include "rtpp_util.h"
 #include "rtpp_pipe.h"
 #include "rtpp_netaddr.h"
 

--- a/src/rtpp_util.c
+++ b/src/rtpp_util.c
@@ -28,7 +28,9 @@
 
 #include <sys/time.h>
 #include <sys/types.h>
+#ifdef __GLIBC__
 #include <sys/sysctl.h>
+#endif
 #include <sys/resource.h>
 #include <errno.h>
 #include <fcntl.h>


### PR DESCRIPTION
Hi all,

I'm updating RTPproxy in OpenWrt from an older checkout (589cc78cb8698b49aa408c6411c8720a2a0efe3c) to a new one. We already have a few patches included ([see here](https://github.com/openwrt/telephony/tree/master/net/rtpproxy)), but for RTPproxy master a few more are needed. So I'm thinking it would be nice if we can get most of them upstream :-)

If you don't like any particular patch I can amend it or drop it altogether, no problem.

This was compile-tested on OpenWrt master with musl libc and gcc-7.4.0. I runtested this on a mips big endian router with kamailio 5.2.4 with rtpproxy_manage("cor").

Kind regards,
Seb