### PR TITLE
Update rtpproxy.in.freebsd

### DIFF
--- a/scripts/rtpproxy.in.freebsd
+++ b/scripts/rtpproxy.in.freebsd
@@ -1,28 +1,30 @@
 #!/bin/sh
 
-# Add the following lines to /etc/rc.conf to enable RTPproxy:
-#
-# rtpproxy_enable="YES"
-
 # PROVIDE: rtpproxy
 # REQUIRE: DAEMON
-# BEFORE: ser openser
+# BEFORE: kamailio opensips
+#
+# Add the following lines to /etc/rc.conf to enable RTPProxy:
+#
+# rtpproxy_enable="YES"
+#
 
-prefix=%%PREFIX%%
-
-. %%RC_SUBR%%
+. /etc/rc.subr
 
 name=rtpproxy
-rcvar=`set_rcvar`
-
-command="${prefix}/bin/rtpproxy"
-pidfile="/var/run/rtpproxy.pid"
-
+rcvar=rtpproxy_enable
 load_rc_config ${name}
 
-rtpproxy_enable=${rtpproxy_enable:-"NO"}
-rtpproxy_laddr=${rtpproxy_laddr:-"0.0.0.0"}
+: ${rtpproxy_enable:="NO"}
+: ${rtpproxy_ctrl_socket:="unix:/var/run/rtpproxy.sock"}
+: ${rtpproxy_laddr:="0.0.0.0"}
+: ${rtpproxy_paddr:="0.0.0.0"}
+: ${rtpproxy_usr:="rtpproxy"}
+: ${rtpproxy_grp:="rtpproxy"}
 
-command_args="-l ${rtpproxy_laddr} -p /var/run/rtpproxy.pid"
+command="%%PREFIX%%/bin/rtpproxy"
+pidfile="/var/run/rtpproxy.pid"
+command_args="-u ${rtpproxy_usr}:${rtpproxy_grp} -A ${rtpproxy_paddr} -l ${rtpproxy_laddr} \
+  -s ${rtpproxy_ctrl_socket} -p ${pidfile}"
 
-run_rc_command "${1}"
+run_rc_command "$1"

--- a/scripts/rtpproxy.in.freebsd
+++ b/scripts/rtpproxy.in.freebsd
@@ -3,6 +3,7 @@
 # PROVIDE: rtpproxy
 # REQUIRE: DAEMON
 # BEFORE: kamailio opensips
+# KEYWORD: shutdown
 #
 # Add the following lines to /etc/rc.conf to enable RTPProxy:
 #


### PR DESCRIPTION
Update rtpproxy.in.freebsd in the upstream source.
This will allow the removable of 'files/patch-scripts_rtpproxy.in.freebsd' in the FreeBSD port.