### PR TITLE
Add missing pthread.h in rtpp_proc_async

### DIFF
--- a/src/rtpp_proc_async.h
+++ b/src/rtpp_proc_async.h
@@ -28,6 +28,8 @@
 #ifndef _RTPP_PROC_ASYNC_H_
 #define _RTPP_PROC_ASYNC_H_
 
+#include <pthread.h>
+
 struct rtpp_proc_async;
 struct rtpp_anetio_cf;
 struct rtpp_cfg;


### PR DESCRIPTION
Fix compilation error for missing pthread_t type name.

rtpp_proc_async.h:44:34: error: unknown type name 'pthread_t'
   44 | void rtpp_proc_async_setprocname(pthread_t thread_id, const char *pname);
      |                                  ^~~~~~~~~